### PR TITLE
Don't multiply timestamp by 1000. It's already in milliseconds

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -48,7 +48,7 @@ class Dashing.Widget extends Batman.View
 
   @accessor 'updatedAtMessage', ->
     if updatedAt = @get('updatedAt')
-      timestamp = new Date(updatedAt * 1000)
+      timestamp = new Date(updatedAt)
       hours = timestamp.getHours()
       minutes = ("0" + timestamp.getMinutes()).slice(-2)
       "Last updated at #{hours}:#{minutes}"


### PR DESCRIPTION
The `send_event` function in `lib/dashing.js` uses `Date.now();` to set the `updatedAt` timestamp in the event payload. This results in a millisecond-accurate timestamp. Therefore there's no need to multiply it by 1000 in the base widget code.
